### PR TITLE
[FIX] project_task_merge: Take the task state with the least sequence.

### DIFF
--- a/project_task_merge/models/project_task.py
+++ b/project_task_merge/models/project_task.py
@@ -14,6 +14,8 @@ class ProjectTask(models.Model):
             tasks._merge_tasks()
 
     def _merge_tasks(self):
+        task_types = self.env['project.task.type'].search([])
+        task_type = min(task_types, key=lambda x: x.sequence)
         min_task = min(self, key=lambda x: x.id)
         name = min_task.name
         description = u'{}: {}'.format(min_task.name, min_task.description)
@@ -30,7 +32,7 @@ class ProjectTask(models.Model):
                 'date_end': False,
                 'date_last_stage_update': fields.Datetime.now(),
                 'planned_hours': sum(self.mapped('planned_hours')),
-                'stage_id': self.env.ref('project.project_tt_analysis').id,
+                'stage_id': task_type.id,
                 'categ_ids': [(6, 0, categs.ids)] if categs else [(6, 0, [])]}
         deadline_tasks = self.filtered(lambda x: x.date_deadline)
         if deadline_tasks:

--- a/project_task_merge/tests/test_project_task_merge.py
+++ b/project_task_merge/tests/test_project_task_merge.py
@@ -10,6 +10,8 @@ class TestProjectTaskMerge(common.TransactionCase):
         super(TestProjectTaskMerge, self).setUp()
         self.project_model = self.env['project.project']
         self.wiz_model = self.env['wiz.project.task.merge']
+        task_types = self.env['project.task.type'].search([])
+        self.task_type = min(task_types, key=lambda x: x.sequence)
         project_vals = {'name': 'Project task merge 1',
                         'use_tasks': True}
         task_vals = {'name': 'Project task merge 1 - task 1',
@@ -35,8 +37,7 @@ class TestProjectTaskMerge(common.TransactionCase):
         self.assertEqual(
             len(task), 1, 'Canceled task not found.')
         task = self.project1.mapped('tasks').filtered(
-            lambda x: x.stage_id.id ==
-            self.env.ref('project.project_tt_analysis').id)
+            lambda x: x.stage_id.id == self.task_type.id)
         self.assertEqual(
             len(task), 1, 'Task not found with analysis state.')
         self.assertEqual(


### PR DESCRIPTION
Coger el estado de tarea con menor secuencia, para la única tarea que queda activa después de mergear.