### PR TITLE
[IMP] project_task_work_estimated_time: No create analytic entries wh…

### DIFF
--- a/project_task_work_estimated_time/models/project_task.py
+++ b/project_task_work_estimated_time/models/project_task.py
@@ -1,13 +1,18 @@
 # -*- coding: utf-8 -*-
 # Copyright 2017 Alfredo de la Fuente - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
-from openerp import fields, models
+from openerp import fields, models, api
 
 
 class ProjectTask(models.Model):
     _inherit = 'project.task'
 
     work_ids = fields.One2many(copy=True)
+
+    @api.multi
+    def copy(self, default=None):
+        return super(ProjectTask,
+                     self.with_context(no_analytic_entry=True)).copy(default)
 
 
 class ProjectTaskWork(models.Model):

--- a/project_task_work_estimated_time/tests/__init__.py
+++ b/project_task_work_estimated_time/tests/__init__.py
@@ -1,0 +1,4 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+from . import test_project_task_work_estimated_time

--- a/project_task_work_estimated_time/tests/test_project_task_work_estimated_time.py
+++ b/project_task_work_estimated_time/tests/test_project_task_work_estimated_time.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+# Copyright 2017 Alfredo de la Fuente - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+import openerp.tests.common as common
+
+
+class TestProjectTaskWorkEstimatedtime(common.TransactionCase):
+
+    def setUp(self):
+        super(TestProjectTaskWorkEstimatedtime, self).setUp()
+        task_vals = {'name': 'Project task estimated time',
+                     'description': 'This is the description'}
+        work_vals = {'name': 'Project task work 1',
+                     'estimated_time': 5.00,
+                     'hours': 6.00}
+        task_vals['work_ids'] = [(0, 0, work_vals)]
+        self.task = self.env['project.task'].create(task_vals)
+
+    def test_project_task_work_estimated_time(self):
+        new_task = self.task.copy()
+        self.assertEquals(new_task.description, 'This is the description')
+        self.assertEquals(len(new_task.work_ids), 1)
+        self.assertEquals(new_task.work_ids[0].name, 'Project task work 1')
+        self.assertEquals(new_task.work_ids[0].estimated_time, 5.0)
+        self.assertEquals(new_task.work_ids[0].hours, 0.0)


### PR DESCRIPTION
…en duplicate project task.
No crear entradas de análitica cuando se duplica una tarea.