### PR TITLE
[IMP] project-characterization: Create new tables area.specialization…

### DIFF
--- a/project_characterization/README.rst
+++ b/project_characterization/README.rst
@@ -20,3 +20,4 @@ Contributors
 ------------
 * Maite Esnal <maiteesnal@avanzosc.es>
 * Ana Juaristi <anajuaristi@avanzosc.es>
+* Xanti Pablo <xantipablo@avanzosc.es>

--- a/project_characterization/__manifest__.py
+++ b/project_characterization/__manifest__.py
@@ -20,6 +20,8 @@
         "views/project_project_view.xml",
         "views/project_task_view.xml",
         "views/project_characterization_view.xml",
+        "views/res_partner_view.xml",
+        "data/project_characterization_data.xml",
     ],
     "installable": True,
     "auto_install": False,

--- a/project_characterization/data/project_characterization_data.xml
+++ b/project_characterization/data/project_characterization_data.xml
@@ -1,0 +1,242 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <data noupdate="1">
+
+        <!-- project.area -->
+    <record id="project_area_direccion_general" model="project.area">
+        <field name="name">Dirección General</field>
+    </record>
+    <record id="project_area_comercial" model="project.area">
+        <field name="name">Comercial</field>
+    </record>
+    <record id="project_area_tecnica" model="project.area">
+        <field name="name">Técnica</field>
+    </record>
+    <record id="project_area_administracion" model="project.area">
+        <field name="name">Administración</field>
+    </record>
+    <record id="project_area_rrhh" model="project.area">
+        <field name="name">RRHH</field>
+    </record>
+    <record id="project_area_calidad" model="project.area">
+        <field name="name">Calidad</field>
+    </record>
+
+        <!-- project.committee -->
+    <record id="project_committee_junta_directiva" model="project.committee">
+        <field name="name">Junta Directiva</field>
+    </record>
+    <record id="project_committee_sistemas_imformacion" model="project.committee">
+        <field name="name">Sistemas Información</field>
+    </record>
+    <record id="project_committee_subcomite_erp" model="project.committee">
+        <field name="name">Subcomité ERP</field>
+    </record>
+    <record id="project_committee_micropymes" model="project.committee">
+        <field name="name">MicroPymes</field>
+    </record>
+    <record id="project_committee_comite_videojuegos_gamificacion" model="project.committee">
+        <field name="name">Comité Videojuegos Gamificación</field>
+    </record>
+    <record id="project_committee_comite_electronica" model="project.committee">
+        <field name="name">Comité Electrónica</field>
+    </record>
+    <record id="project_committee_comite_ingenieria_electronica" model="project.committee">
+        <field name="name">Comité Ingeniería-Electrónica</field>
+    </record>
+    <record id="project_committee_comite_ingenieria" model="project.committee">
+        <field name="name">Comité Ingeniería</field>
+    </record>
+    <record id="project_committee_comite_electronica" model="project.committee">
+        <field name="name">Comité Electrónica</field>
+    </record>
+
+        <!-- project.structures -->
+    <record id="project_structures_gne" model="project.structures">
+        <field name="name">GNE</field>
+    </record>
+    <record id="project_structures_basquelabgame" model="project.structures">
+        <field name="name">BASQUEGAMELAB</field>
+    </record>
+    <record id="project_structures_isare" model="project.structures">
+        <field name="name">ISARE</field>
+    </record>
+    
+        <!-- project.oportunity.spaces -->
+    <record id="project_oportunity_spaces_smart_industry" model="project.oportunity.spaces">
+        <field name="name">Smart Industry</field>
+    </record>
+    <record id="project_oportunity_spaces_smart_territory" model="project.oportunity.spaces">
+        <field name="name">Smart Territory</field>
+    </record>
+    <record id="project_oportunity_spaces_smart_society" model="project.oportunity.spaces">
+        <field name="name">Smart Society</field>
+    </record>
+    
+        <!-- project.area.specialization -->
+    <record id="project_area_specialization_gestion_avanzada" model="project.area.specialization">
+        <field name="name">Gestión Avanzada</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_asistencia_a_profesionales" model="project.area.specialization">
+        <field name="name">Asistencia a profesionales</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_gestion_servicios_40" model="project.area.specialization">
+        <field name="name">Gestión Servicios 4.0</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_tecnologias_digitalizacion" model="project.area.specialization">
+        <field name="name">Tecnoligías de Digitalización</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_transferencia_conocimiento" model="project.area.specialization">
+        <field name="name">Transferancia de Conocimiento</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_customizacion_visualizacion" model="project.area.specialization">
+        <field name="name">Customización y Visualización</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_eficiencia_energetica" model="project.area.specialization">
+        <field name="name">Eficiencia Energética</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_eficiencia_otros_recursos" model="project.area.specialization">
+        <field name="name">Eficiencia otros Recursos</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_eficiencia_reciclado" model="project.area.specialization">
+        <field name="name">Eficiencia en Reciclado</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_gestion_informacion" model="project.area.specialization">
+        <field name="name">Gestión de la Información</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_asistencia_tecnologica" model="project.area.specialization">
+        <field name="name">Asistencia Tecnológica</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_mantenimiento_inteligente_sat" model="project.area.specialization">
+        <field name="name">Mantenimiento Inteligente y SAT</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_gestion_consumibles_repuestos" model="project.area.specialization">
+        <field name="name">Gestión de Consumibles y Repuestos</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_inteligancia_producto" model="project.area.specialization">
+        <field name="name">Inteligencia a Producto</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_inteligencia_proceso" model="project.area.specialization">
+        <field name="name">Inteligencia en Proceso</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_inteligencia_logistica" model="project.area.specialization">
+        <field name="name">Inteligencia en Logística</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_ciberseguridad" model="project.area.specialization">
+        <field name="name">Ciberseguridad</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_otros" model="project.area.specialization">
+        <field name="name">Otros (especificar)</field>
+        <field name="oportunity_spaces_id">1</field>
+    </record>
+    <record id="project_area_specialization_reciclado_residuos" model="project.area.specialization">
+        <field name="name">Reciclado-Residuos</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_agua_sistemas_inteligentes_gestion" model="project.area.specialization">
+        <field name="name">Agua. Sistemas inteligentes de gestión</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_redes_telecomunicaciones_avanzadas" model="project.area.specialization">
+        <field name="name">Redes Telecomunicaciones Avanzadas</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_aire_ruido" model="project.area.specialization">
+        <field name="name">Aire-Ruido. Sistemas inteligentes de Gestión</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_movilidad" model="project.area.specialization">
+        <field name="name">Movilidad. Redes de transporte, Parking, Transporte Público, Infraestructuras</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_seguridad" model="project.area.specialization">
+        <field name="name">Seguridad. Infraestructuras y Gestión Avanzada</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_salud" model="project.area.specialization">
+        <field name="name">Salud. Evolución Redes Sanitarias, Hospitales, Servicios Geriátricos</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_educacion" model="project.area.specialization">
+        <field name="name">Educación. Acompañamiento a Centros Educativos en su evolución</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_urbanismo" model="project.area.specialization">
+        <field name="name">Urbanismo. Sistemas inteligentes de Gestión</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_economia_impuestos" model="project.area.specialization">
+        <field name="name">Economía e Impuestos. Marcos para la Nueva Economía</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_otros" model="project.area.specialization">
+        <field name="name">Otros (esoecificar)</field>
+        <field name="oportunity_spaces_id">2</field>
+    </record>
+    <record id="project_area_specialization_talento_educacion" model="project.area.specialization">
+        <field name="name">Talento y Educación</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_legislacion_normas" model="project.area.specialization">
+        <field name="name">Legislación y Normas</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_modelos_economicos" model="project.area.specialization">
+        <field name="name">Modelos Económicos - Trabajo</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_innovacion_emprendizaje" model="project.area.specialization">
+        <field name="name">Innovación y emprendizaje </field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_rrss_participacion_ciudadana" model="project.area.specialization">
+        <field name="name">Redes Sociales y Participación Ciudadana</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_concienciacion_medio_ambiente" model="project.area.specialization">
+        <field name="name">Concienciación Medio Ambiente</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_movilidad_compartida_sostenible" model="project.area.specialization">
+        <field name="name">Movilidad. Compartida y Sostenible</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_seguridad_ciudadana" model="project.area.specialization">
+        <field name="name">Seguridad Ciudadana</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_salud_hogar" model="project.area.specialization">
+        <field name="name">Salud en el hogar. Cultura de la salud</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_economia_plateada" model="project.area.specialization">
+        <field name="name">Economía Plateada</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_gobernanza_participativa" model="project.area.specialization">
+        <field name="name">Gobernanza Participativa</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    <record id="project_area_specialization_otros" model="project.area.specialization">
+        <field name="name">Otros (especificar)</field>
+        <field name="oportunity_spaces_id">3</field>
+    </record>
+    </data>
+</odoo>

--- a/project_characterization/i18n/.directory
+++ b/project_characterization/i18n/.directory
@@ -1,0 +1,4 @@
+[Dolphin]
+Timestamp=2018,4,26,11,19,17
+Version=3
+ViewMode=1

--- a/project_characterization/i18n/es.po
+++ b/project_characterization/i18n/es.po
@@ -1,19 +1,37 @@
 # Translation of Odoo Server.
 # This file contains the translation of the following modules:
-#	* project_characterization
+# 	* project_characterization
 #
 msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-04-13 10:13+0000\n"
-"PO-Revision-Date: 2018-04-13 10:13+0000\n"
+"POT-Creation-Date: 2018-05-03 08:47+0000\n"
+"PO-Revision-Date: 2018-05-03 10:50+0200\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"Language: es\n"
+"X-Generator: Poedit 1.8.7.1\n"
+
+#. module: project_characterization
+#: model:ir.actions.act_window,name:project_characterization.action_funding_source_from_partner
+msgid " Funding Sources"
+msgstr "Programas de financiación"
+
+#. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.view_funding_source_from_partner
+msgid "# Fuding Source"
+msgstr "# Programa de Financiación"
+
+#. module: project_characterization
+#: model:ir.model.fields,field_description:project_characterization.field_res_partner_funding_source_count
+#: model:ir.model.fields,field_description:project_characterization.field_res_users_funding_source_count
+msgid "#Funding Sources"
+msgstr "#Programa de Financiación"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_account_analytic_account
@@ -23,16 +41,43 @@ msgstr "Cuenta analítica"
 #. module: project_characterization
 #: model:ir.actions.act_window,name:project_characterization.project_area_action
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_project_area_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_type_area_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_project_area_id
 #: model:ir.ui.menu,name:project_characterization.project_area_menuitem
+#: model:ir.ui.view,arch_db:project_characterization.project_area_tree_view
 msgid "Area"
 msgstr "Area"
 
 #. module: project_characterization
+#: model:ir.actions.act_window,name:project_characterization.project_area_specialization_action
+#: model:ir.ui.menu,name:project_characterization.project_area_specialization_menuitem
+msgid "Area Specialization"
+msgstr "Área de especialización"
+
+#. module: project_characterization
 #: model:ir.actions.act_window,name:project_characterization.project_area_type_action
 #: model:ir.ui.menu,name:project_characterization.project_area_type_menuitem
+#: model:ir.ui.view,arch_db:project_characterization.project_area_type_form_view
+#: model:ir.ui.view,arch_db:project_characterization.project_area_type_tree_view
 msgid "Area Type"
-msgstr "Tipo de area"
+msgstr "Tipo de proyecto"
+
+#. module: project_characterization
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_type_ids
+msgid "Area Types"
+msgstr "Tipos de proyectos"
+
+#. module: project_characterization
+#: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_project_area_type_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_project_project_area_type_id
+#: model:ir.ui.view,arch_db:project_characterization.project_area_type_form_view
+msgid "Area type"
+msgstr "Tipo de proyecto"
+
+#. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
+msgid "Areas"
+msgstr "Areas"
 
 #. module: project_characterization
 #: model:ir.actions.act_window,name:project_characterization.project_character_action
@@ -49,12 +94,32 @@ msgid "Characterization"
 msgstr "Caracterización"
 
 #. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
+msgid "Characters"
+msgstr "Naturaleza"
+
+#. module: project_characterization
+#: model:ir.actions.act_window,name:project_characterization.project_committee_action
+#: model:ir.ui.menu,name:project_characterization.project_committee_menuitem
+msgid "Committee"
+msgstr "Comité GAIA"
+
+#. module: project_characterization
+#: model:ir.model,name:project_characterization.model_res_partner
+msgid "Contact"
+msgstr "Contacto"
+
+#. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_create_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_create_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_create_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_create_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_create_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_create_uid
@@ -65,9 +130,13 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_create_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_create_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_create_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_create_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_create_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_create_date
@@ -75,12 +144,22 @@ msgid "Created on"
 msgstr "Creado en"
 
 #. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
+msgid "Departments"
+msgstr "Departamentos"
+
+#. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_description
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_description
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_description
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_description
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_description
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_description
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_description
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_description
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_description
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_description
+#: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_description
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_description
 msgid "Description"
 msgstr "Descripción"
@@ -89,14 +168,25 @@ msgstr "Descripción"
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_display_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_display_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_display_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_display_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_display_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_display_name
 msgid "Display Name"
 msgstr "Nombre mostrado"
+
+#. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.project_project_form_view
+#: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
+#: model:ir.ui.view,arch_db:project_characterization.project_project_tree_view
+msgid "End Date"
+msgstr "Fecha Fin"
 
 #. module: project_characterization
 #: model:ir.actions.act_window,name:project_characterization.funding_source_action
@@ -128,17 +218,24 @@ msgstr "Funding Source Tree"
 #: model:ir.model,name:project_characterization.model_funding_source_type
 #: model:ir.ui.menu,name:project_characterization.funding_source_type_menuitem
 msgid "Funding Source Type"
-msgstr "Funding Source Type"
+msgstr "Tipos de programas de financiación"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.funding_source_type_search_view
 msgid "Funding Source Type Search"
-msgstr "Funding Source Type Search"
+msgstr "Buscar Tipo de Fuente de Financiación"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.funding_source_type_tree_view
 msgid "Funding Source Type Tree"
 msgstr "Funding Source Type Tree"
+
+#. module: project_characterization
+#: model:ir.model.fields,field_description:project_characterization.field_res_partner_funding_source_id
+#: model:ir.model.fields,field_description:project_characterization.field_res_users_funding_source_id
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
+msgid "Funding Sources"
+msgstr "Programas de Financiación"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_id
@@ -152,11 +249,15 @@ msgstr "Grant"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_id
-#: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_id_4792
+#: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_id_4300
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_id
-#: model:ir.model.fields,field_description:project_characterization.field_project_area_type_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_type_id_4329
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_id
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_id
@@ -179,9 +280,13 @@ msgstr "Fecha límite de justificación"
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_area___last_update
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_character___last_update
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee___last_update
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_space___last_update
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_target___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2___last_update
 #: model:ir.model.fields,field_description:project_characterization.field_project_team___last_update
@@ -191,10 +296,14 @@ msgstr "Última modificación en"
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_write_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_write_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_write_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_write_uid
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_write_uid
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_write_uid
@@ -204,10 +313,14 @@ msgstr "Última actualización de"
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_write_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_write_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_write_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_write_date
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_write_date
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_write_date
@@ -223,13 +336,25 @@ msgstr "Mixed Credit"
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_name
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_type_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_area_type_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_character_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_committee_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_oportunity_spaces_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_space_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_structures_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_target_name
+#: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_name
 #: model:ir.model.fields,field_description:project_characterization.field_project_team_name
 msgid "Name"
 msgstr "Nombre"
+
+#. module: project_characterization
+#: model:ir.actions.act_window,name:project_characterization.project_oportunity_spaces_action
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_specialization_oportunity_spaces_id
+#: model:ir.ui.menu,name:project_characterization.project_oportunity_spaces_menuitem
+msgid "Oportunity Spaces"
+msgstr "Espacios de oportunidad"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_partner_id
@@ -242,9 +367,25 @@ msgid "Period"
 msgstr "Período"
 
 #. module: project_characterization
+#: model:ir.model,name:project_characterization.model_project_project
+#: model:ir.model.fields,field_description:project_characterization.field_project_area_type_project_id
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_task_type2_form_view
 msgid "Project Task Type"
 msgstr "Tipo de tarea"
+
+#. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.project_area_search_view
+msgid "Search area"
+msgstr "Buscar área"
+
+#. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.project_area_type_search_view
+msgid "Search area type"
+msgstr "Search area type"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_funding_source_soft_credit
@@ -260,6 +401,17 @@ msgid "Space"
 msgstr "Espacio"
 
 #. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
+msgid "Spaces"
+msgstr "Espacios"
+
+#. module: project_characterization
+#: model:ir.actions.act_window,name:project_characterization.project_structures_action
+#: model:ir.ui.menu,name:project_characterization.project_structures_menuitem
+msgid "Structures"
+msgstr "Estructuras GAIA"
+
+#. module: project_characterization
 #: model:ir.actions.act_window,name:project_characterization.project_target_action
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_project_target_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_project_target_id
@@ -268,14 +420,14 @@ msgid "Target"
 msgstr "Sector Objetivo"
 
 #. module: project_characterization
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
+msgid "Targets"
+msgstr "Sectores Objetivos"
+
+#. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_task
 msgid "Task"
 msgstr "Tarea"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_task_type
-msgid "Task Stage"
-msgstr "Etapa de la tarea"
 
 #. module: project_characterization
 #: model:ir.actions.act_window,name:project_characterization.project_team_action
@@ -286,68 +438,29 @@ msgstr "Equipo"
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_project_team_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_project_team_id
+#: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Teams"
 msgstr "Equipo"
 
 #. module: project_characterization
-#: model:ir.model.fields,field_description:project_characterization.field_project_task_type_id_4801
+#: model:ir.model.fields,field_description:project_characterization.field_project_task_type_id_4307
 msgid "Type"
 msgstr "Tipo"
 
 #. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_area
-msgid "account.area"
-msgstr "account.area"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_espaces
-msgid "account.espaces"
-msgstr "account.espaces"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_financiation
-msgid "account.financiation"
-msgstr "account.financiation"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_nature
-msgid "account.nature"
-msgstr "account.nature"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_opportunity
-msgid "account.opportunity"
-msgstr "account.opportunity"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_pe
-msgid "account.pe"
-msgstr "account.pe"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_sector_objetive
-msgid "account.sector_objetive"
-msgstr "account.sector_objetive"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_account_teams
-msgid "account.teams"
-msgstr "account.teams"
-
-#. module: project_characterization
-#: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_description
-msgid "description"
-msgstr "description"
-
-#. module: project_characterization
-#: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_name
+#: model:ir.ui.view,arch_db:project_characterization.project_area_type_form_view
 msgid "name"
-msgstr "name"
+msgstr "Nombre"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_area
 msgid "project.area"
 msgstr "project.area"
+
+#. module: project_characterization
+#: model:ir.model,name:project_characterization.model_project_area_specialization
+msgid "project.area.specialization"
+msgstr "project.area.specialization"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_area_type
@@ -360,39 +473,24 @@ msgid "project.character"
 msgstr "project.character"
 
 #. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_espaces
-msgid "project.espaces"
-msgstr "project.espaces"
+#: model:ir.model,name:project_characterization.model_project_committee
+msgid "project.committee"
+msgstr "project.committee"
 
 #. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_financiation
-msgid "project.financiation"
-msgstr "project.financiation"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_id
-msgid "project.id"
-msgstr "project.id"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_nature
-msgid "project.nature"
-msgstr "project.nature"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_pe
-msgid "project.pe"
-msgstr "project.pe"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_sector_objetive
-msgid "project.sector_objetive"
-msgstr "project.sector_objetive"
+#: model:ir.model,name:project_characterization.model_project_oportunity_spaces
+msgid "project.oportunity.spaces"
+msgstr "project.oportunity.spaces"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_space
 msgid "project.space"
 msgstr "project.space"
+
+#. module: project_characterization
+#: model:ir.model,name:project_characterization.model_project_structures
+msgid "project.structures"
+msgstr "project.structures"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_target
@@ -408,14 +506,3 @@ msgstr "project.task.type2"
 #: model:ir.model,name:project_characterization.model_project_team
 msgid "project.team"
 msgstr "project.team"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_project_teams
-msgid "project.teams"
-msgstr "project.teams"
-
-#. module: project_characterization
-#: model:ir.model,name:project_characterization.model_task_phase
-msgid "task.phase"
-msgstr "task.phase"
-

--- a/project_characterization/models/account_analytic.py
+++ b/project_characterization/models/account_analytic.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Maite Esnal - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class AccountAnalyticAccount(models.Model):
@@ -22,3 +22,8 @@ class AccountAnalyticAccount(models.Model):
     department_id = fields.Many2one(
         comodel_name='hr.department', string='Internal Services Department')
     justification_deadline = fields.Date(string='Justification Deadline')
+    project_area_type_id = fields.Many2one(
+        comodel_name='project.area.type', string='Area type',
+        domain="[('area_id','=',project_area_id)]",
+        ondelete='cascade')
+

--- a/project_characterization/models/funding_source.py
+++ b/project_characterization/models/funding_source.py
@@ -1,7 +1,7 @@
 # Copyright 2018 Maite Esnal - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class FundingSource(models.Model):
@@ -26,3 +26,22 @@ class FundingSourceType(models.Model):
     _description = 'Funding Source Type'
 
     name = fields.Char(string='Name')
+
+
+class ResPartner(models.Model):
+    _inherit = 'res.partner'
+
+    @api.one
+    def _funding_source_count(self):
+        funding_source_obj = self.env['funding.source']
+        self.funding_source_count = 0
+        cond = [('partner_id', '=', self.id)]
+        funding_sources = funding_source_obj.search(cond)
+        if funding_sources:
+            self.funding_source_count = len(funding_sources)
+
+    funding_source_id = fields.One2many(comodel_name='funding.source',
+                                        string='Funding Sources',
+                                        inverse_name='partner_id')
+    funding_source_count = fields.Integer(string='#Funding Sources',
+                                          compute=_funding_source_count)

--- a/project_characterization/models/project_project.py
+++ b/project_characterization/models/project_project.py
@@ -2,7 +2,7 @@
 # Copyright 2018 Oihane Crucelaegui - AvanzOSC
 # License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class ProjectArea(models.Model):
@@ -10,7 +10,8 @@ class ProjectArea(models.Model):
 
     name = fields.Char(string='Name', required=True)
     description = fields.Text(string='Description')
-    type_id = fields.Many2one(comodel_name='project.area.type', string='Type')
+    type_ids = fields.One2many(comodel_name='project.area.type',
+                               string='Area Types', inverse_name='area_id')
 
 
 class ProjectAreaType(models.Model):
@@ -18,6 +19,10 @@ class ProjectAreaType(models.Model):
 
     name = fields.Char(string='Name', required=True)
     description = fields.Text(string='Description')
+    area_id = fields.Many2one(string='Area', comodel_name='project.area')
+    project_id = fields.One2many(comodel_name='project.project',
+                                 inverse_name='project_area_type_id',
+                                 string='Project')
 
 
 class ProjectEspaces(models.Model):
@@ -46,3 +51,44 @@ class ProjectTarget(models.Model):
 
     name = fields.Char(string='Name', required=True)
     description = fields.Text(string='Description')
+
+
+class ProjectProject(models.Model):
+    _inherit = 'project.project'
+
+    @api.onchange('project_area_id')
+    def _onchange_project_area_id(self):
+        self.project_area_type_id = False
+
+
+class ProjectCommittee(models.Model):
+    _name = 'project.committee'
+
+    name = fields.Char(string='Name', required=True)
+    description = fields.Text(string='Description')
+
+
+class ProjectStructures(models.Model):
+    _name = 'project.structures'
+
+    name = fields.Char(string='Name', required=True)
+    description = fields.Text(string='Description')
+
+
+class ProjectOportunitySpaces(models.Model):
+    _name = 'project.oportunity.spaces'
+
+    name = fields.Char(string='Name', required=True)
+    description = fields.Text(string='Description')
+
+
+class ProjectAreaSpecialization(models.Model):
+    _name = 'project.area.specialization'
+
+    name = fields.Char(string='Name', required=True)
+    description = fields.Text(string='Description')
+
+    oportunity_spaces_id = fields.Many2one(
+        comodel_name='project.oportunity.spaces',
+        required=True,
+        string='Oportunity Spaces')

--- a/project_characterization/views/account_analytic_view.xml
+++ b/project_characterization/views/account_analytic_view.xml
@@ -46,4 +46,31 @@
             </field>
         </field>
     </record>
+
+    <record id="view_account_analytic_account_search_inh_project_char" model="ir.ui.view">
+        <field name="name">view.account.analytic.account.search.inh.project.char</field>
+        <field name="model">account.analytic.account</field>
+        <field name="inherit_id"
+               ref="analytic.view_account_analytic_account_search" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                    <field name="project_team_id" />
+                    <field name="project_character_id" />
+                    <field name="project_target_id" />
+                    <field name="project_area_id" />
+                    <field name="department_id" />
+                    <field name="project_space_id" />
+                    <field name="funding_source_id" />
+            </field>
+            <group position="inside">
+                <filter name="group_teams" string="Teams" domain="[]" context="{'group_by':'project_team_id'}"/>
+                <filter name="group_character" string="Characters" domain="[]" context="{'group_by':'project_character_id'}"/>
+                <filter name="group_target" string="Targets" domain="[]" context="{'group_by':'project_target_id'}"/>
+                <filter name="group_area" string="Areas" domain="[]" context="{'group_by':'project_area_id'}"/>
+                <filter name="group_department" string="Departments" domain="[]" context="{'group_by':'department_id'}"/>
+                <filter name="group_space" string="Spaces" domain="[]" context="{'group_by':'project_space_id'}"/>
+                <filter name="group_funding_source" string="Funding Sources" domain="[]" context="{'group_by':'funding_source_id'}"/>
+            </group>
+        </field>
+    </record>
 </odoo>

--- a/project_characterization/views/funding_source_view.xml
+++ b/project_characterization/views/funding_source_view.xml
@@ -85,5 +85,4 @@
         <field name="search_view_id"
                ref="funding_source_type_search_view"/>
     </record>
-
 </odoo>

--- a/project_characterization/views/project_characterization_view.xml
+++ b/project_characterization/views/project_characterization_view.xml
@@ -27,4 +27,16 @@
     <menuitem id="project_team_menuitem"
               parent="project_characterization_config_menuitem"
               action="project_team_action" />
+    <menuitem id="project_committee_menuitem"
+              parent="project_characterization_config_menuitem"
+              action="project_committee_action" />
+    <menuitem id="project_structures_menuitem"
+              parent="project_characterization_config_menuitem"
+              action="project_structures_action" />
+    <menuitem id="project_oportunity_spaces_menuitem"
+              parent="project_characterization_config_menuitem"
+              action="project_oportunity_spaces_action" />
+    <menuitem id="project_area_specialization_menuitem"
+              parent="project_characterization_config_menuitem"
+              action="project_area_specialization_action" />
 </odoo>

--- a/project_characterization/views/project_project_view.xml
+++ b/project_characterization/views/project_project_view.xml
@@ -17,6 +17,7 @@
                             <field name="project_character_id" />
                             <field name="project_target_id" />
                             <field name="project_area_id" />
+                            <field name="project_area_type_id"/>
                             <field name="department_id"
                                    options="{'no_create': True}" />
                             <field name="alias_user_id" />
@@ -26,7 +27,7 @@
                             <field name="funding_source_id"
                                    options="{'no_create': True}"/>
                             <field name="date_start" />
-                            <field name="date" />
+                            <field name="date" string="End Date"/>
                             <field name="justification_deadline" />
                         </group>
                     </group>
@@ -50,12 +51,78 @@
                 <field name="project_space_id" />
                 <field name="funding_source_id" />
                 <field name="date_start" />
-                <field name="date" />
+                <field name="date" string="End Date"/>
                 <field name="justification_deadline" />
             </tree>
         </field>
     </record>
 
+<!--Nuevas vistas para el modelo project.area.type-->
+    <record id="project_area_type_tree_view" model="ir.ui.view">
+        <field name="name">project.area.type.tree.view</field>
+        <field name="model">project.area.type</field>
+        <field name="arch" type="xml">
+            <tree string="Area Type">
+                <field name="name"/>
+                <field name="description"/>
+                <field name="area_id"/>
+            </tree>
+        </field>
+    </record>
+    
+    <record id="project_area_type_search_view" model="ir.ui.view">
+        <field name="name">project.area.type.search</field>
+        <field name="model">project.area.type</field>
+        <field name="arch" type="xml">
+            <search string="Search area type">
+                <field name="name" />
+                <field name="description" />
+                <field name="area_id" />
+            </search>
+        </field>
+    </record>
+    
+    <record id="project_area_tree_view" model="ir.ui.view">
+        <field name="name">project.area.tree.view</field>
+        <field name="model">project.area</field>
+        <field name="arch" type="xml">
+            <tree string="Area">
+                <field name="name"/>
+                <field name="description"/>
+            </tree>
+        </field>
+    </record>
+    
+    <record id="project_area_search_view" model="ir.ui.view">
+        <field name="name">project.area.search</field>
+        <field name="model">project.area</field>
+        <field name="arch" type="xml">
+            <search string="Search area">
+                <field name="name" />
+                <field name="description" />
+            </search>
+        </field>
+    </record>
+    
+    <record id="project_area_type_form_view" model="ir.ui.view">
+       <field name="name">project.area.type.form.view</field>
+       <field name="model">project.area.type</field>
+       <field name="arch" type="xml">
+           <form string="Area type">
+               <sheet>
+                   <h1>
+                       <label string="Area Type" />
+                       <field name="name" class="oe_inline" string="name"/>
+                   </h1>
+                   <group name="head" colspan="4" col="8" >
+                       <field name="description" colspan="8" />
+                       <field name="area_id" colspan="6"/>
+                    </group>
+                </sheet>
+           </form>
+        </field>
+    </record>
+    
     <record id="project_project_search_view" model="ir.ui.view">
         <field name="name">project.project.search</field>
         <field name="model">project.project</field>
@@ -71,7 +138,7 @@
                 <field name="project_space_id" />
                 <field name="funding_source_id" />
                 <field name="date_start" />
-                <field name="date" />
+                <field name="date" string="End Date"/>
                 <field name="justification_deadline" />
             </search>
         </field>
@@ -123,5 +190,63 @@
         <field name="view_mode">tree,form</field>
         <field name="context">{
         }</field>
+    </record>
+
+    <record id="project_committee_action" model="ir.actions.act_window">
+        <field name="name">Committee</field>
+        <field name="res_model">project.committee</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{
+        }</field>
+    </record>
+
+    <record id="project_structures_action" model="ir.actions.act_window">
+        <field name="name">Structures</field>
+        <field name="res_model">project.structures</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{
+        }</field>
+    </record>
+
+    <record id="project_oportunity_spaces_action" model="ir.actions.act_window">
+        <field name="name">Oportunity Spaces</field>
+        <field name="res_model">project.oportunity.spaces</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{
+        }</field>
+    </record>
+
+    <record id="project_area_specialization_action" model="ir.actions.act_window">
+        <field name="name">Area Specialization</field>
+        <field name="res_model">project.area.specialization</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{
+        }</field>
+    </record>
+    
+        
+    <record id="project_area_specialization_tree_view" model="ir.ui.view">
+        <field name="name">project.area.specialization.tree.view</field>
+        <field name="model">project.area.specialization</field>
+        <field name="arch" type="xml">
+            <tree string="Area">
+                <field name="name"/>
+                <field name="description"/>
+                <field name="oportunity_spaces_id"/>
+            </tree>
+        </field>
+    </record>
+
+    
+    <record id="project_area_specialization_search_view" model="ir.ui.view">
+        <field name="name">project.area.specialization.search</field>
+        <field name="model">project.area.specialization</field>
+        <field name="arch" type="xml">
+            <search string="Search area">
+                <field name="name" />
+                <field name="description" />
+                <field name="oportunity_spaces_id"/>
+            </search>
+        </field>
     </record>
 </odoo>

--- a/project_characterization/views/res_partner_view.xml
+++ b/project_characterization/views/res_partner_view.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8"?>
+<openerp>
+    <data>
+
+    <!-- ACCION DEFINIDA PARA EL ATAJO -->
+    <record id="action_funding_source_from_partner" model="ir.actions.act_window">
+        <field name="name"> Funding Sources</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">funding.source</field>
+        <field name="view_type">form</field>
+        <field name="view_mode">tree,form</field>
+        <field name="context">{'default_partner':active_id,'search_default_partner':active_id}</field>
+        <field name="domain">[('partner_id','=',active_id)]</field>
+    </record>
+
+    <!-- VISTA DE FORMULARIO -->
+    <record id="view_funding_source_from_partner" model="ir.ui.view">
+        <field name="name">view.funding.source.from.partner</field>
+        <field name="model">res.partner</field>
+        <field name="inherit_id" ref="base.view_partner_form"/>
+        <field name="arch" type="xml">
+        <xpath expr="//div[@name='button_box']" position="inside">
+            <button name="%(action_funding_source_from_partner)d" type="action"
+                    class="oe_inline oe_stat_button" icon="fa-bookmark-o">
+                <field string="# Fuding Source" name="funding_source_count" widget="statinfo"/>
+            </button>
+        </xpath>
+        </field>
+    </record>
+
+    </data>
+</openerp>


### PR DESCRIPTION
-  En partners: añadir pestaña o atajo a "programas de financiación"
- Tipo de proyecto, depende de Area por tanto, será necesario añadir el campo "Area: Many2one a áreas" en el tipo.  Posteriormente, meter un domain en tipos de proyecto, donde sólo muestre aquellos que determine su área.
- Cambiar etiquetas:               - Fecha de caducidad por fecha fin
- Creación de objetos y sus datos:
    - Area de especialización
    - Comités GAIA
    - Estructuras GAIA
    - Espacios de Oportunidad
