### PR TITLE
[ADD] New module project_version

### DIFF
--- a/project_version/README.rst
+++ b/project_version/README.rst
@@ -1,0 +1,29 @@
+.. image:: https://img.shields.io/badge/license-AGPL--3-blue.png
+   :target: https://www.gnu.org/licenses/agpl
+   :alt: License: AGPL-3
+
+===============
+Project Version
+===============
+
+Configuration
+=============
+
+Bug Tracker
+===========
+
+Bugs are tracked on `GitHub Issues
+<https://github.com/avanzosc/project-addons/issues>`_. In case of trouble,
+please check there if your issue has already been reported. If you spotted
+it first, help us smash it by providing detailed and welcomed feedback.
+
+Credits
+=======
+
+Contributors
+------------
+
+* Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>
+* Ana Juaristi <anajuaristi@avanzosc.es>
+
+Do not contact contributors directly about support or help with technical issues.

--- a/project_version/__init__.py
+++ b/project_version/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import models

--- a/project_version/__manifest__.py
+++ b/project_version/__manifest__.py
@@ -16,7 +16,6 @@
         "project",
     ],
     "data": [
-        # "data/project_budget_data.xml",
         "views/project_project_view.xml",
     ],
     "installable": True,

--- a/project_version/__manifest__.py
+++ b/project_version/__manifest__.py
@@ -1,0 +1,23 @@
+# Copyright 2018 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+{
+    "name": "Project Version",
+    "version": "11.0.1.0.0",
+    "category": "Project",
+    "license": "AGPL-3",
+    "author": "AvanzOSC",
+    "website": "http://www.avanzosc.es",
+    "contributors": [
+        "Oihane Crucelaegui <oihanecrucelaegi@avanzosc.es>",
+        "Ana Juaristi <anajuaristi@avanzosc.es>",
+    ],
+    "depends": [
+        "project",
+    ],
+    "data": [
+        # "data/project_budget_data.xml",
+        "views/project_project_view.xml",
+    ],
+    "installable": True,
+}

--- a/project_version/i18n/es.po
+++ b/project_version/i18n/es.po
@@ -1,0 +1,83 @@
+# Translation of Odoo Server.
+# This file contains the translation of the following modules:
+#	* project_version
+#
+msgid ""
+msgstr ""
+"Project-Id-Version: Odoo Server 11.0\n"
+"Report-Msgid-Bugs-To: \n"
+"POT-Creation-Date: 2018-11-28 13:46+0000\n"
+"PO-Revision-Date: 2018-11-28 13:46+0000\n"
+"Last-Translator: <>\n"
+"Language-Team: \n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: \n"
+"Plural-Forms: \n"
+
+#. module: project_version
+#: model:ir.ui.view,arch_db:project_version.project_project_search_view
+msgid "All"
+msgstr "Todos"
+
+#. module: project_version
+#: model:ir.ui.view,arch_db:project_version.project_project_search_view
+msgid "Historified"
+msgstr "Historified"
+
+#. module: project_version
+#: model:ir.model.fields,field_description:project_version.field_project_project_historical_user_id
+msgid "Historified by"
+msgstr "Historified by"
+
+#. module: project_version
+#: model:ir.model.fields,field_description:project_version.field_project_project_historical_date
+msgid "Historified on"
+msgstr "Historified on"
+
+#. module: project_version
+#: model:ir.ui.view,arch_db:project_version.project_project_form_view
+msgid "Historify"
+msgstr "Historify"
+
+#. module: project_version
+#: model:ir.ui.view,arch_db:project_version.project_project_form_view
+msgid "New Version"
+msgstr "New Version"
+
+#. module: project_version
+#: model:ir.actions.act_window,name:project_version.project_project_old_version_action
+#: model:ir.ui.view,arch_db:project_version.project_project_form_view
+msgid "Old Versions"
+msgstr "Old Versions"
+
+#. module: project_version
+#: model:ir.model.fields,field_description:project_version.field_project_project_parent_id
+msgid "Parent Project"
+msgstr "Parent Project"
+
+#. module: project_version
+#: model:ir.model,name:project_version.model_project_project
+msgid "Project"
+msgstr "Proyecto"
+
+#. module: project_version
+#: model:ir.model.fields,field_description:project_version.field_project_project_version
+msgid "Version"
+msgstr "Versión"
+
+#. module: project_version
+#: model:ir.model.fields,field_description:project_version.field_project_project_version_user_id
+msgid "Versioned by"
+msgstr "Versionado por"
+
+#. module: project_version
+#: model:ir.model.fields,field_description:project_version.field_project_project_version_date
+msgid "Versioned on"
+msgstr "Versionado el"
+
+#. module: project_version
+#: model:ir.ui.view,arch_db:project_version.project_project_form_view
+msgid "on"
+msgstr "en"
+

--- a/project_version/i18n/es.po
+++ b/project_version/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-11-28 13:46+0000\n"
-"PO-Revision-Date: 2018-11-28 13:46+0000\n"
+"POT-Creation-Date: 2018-11-29 13:53+0000\n"
+"PO-Revision-Date: 2018-11-29 13:53+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -23,38 +23,44 @@ msgstr "Todos"
 #. module: project_version
 #: model:ir.ui.view,arch_db:project_version.project_project_search_view
 msgid "Historified"
-msgstr "Historified"
+msgstr "Historificado"
 
 #. module: project_version
 #: model:ir.model.fields,field_description:project_version.field_project_project_historical_user_id
 msgid "Historified by"
-msgstr "Historified by"
+msgstr "Historificado por"
 
 #. module: project_version
 #: model:ir.model.fields,field_description:project_version.field_project_project_historical_date
 msgid "Historified on"
-msgstr "Historified on"
+msgstr "Historificado el"
 
 #. module: project_version
 #: model:ir.ui.view,arch_db:project_version.project_project_form_view
 msgid "Historify"
-msgstr "Historify"
+msgstr "Historificar"
+
+#. module: project_version
+#: model:ir.actions.act_window,name:project_version.project_project_history_action
+#: model:ir.ui.view,arch_db:project_version.project_project_form_view
+msgid "History"
+msgstr "Historial"
 
 #. module: project_version
 #: model:ir.ui.view,arch_db:project_version.project_project_form_view
 msgid "New Version"
-msgstr "New Version"
+msgstr "Nueva version"
 
 #. module: project_version
 #: model:ir.actions.act_window,name:project_version.project_project_old_version_action
 #: model:ir.ui.view,arch_db:project_version.project_project_form_view
 msgid "Old Versions"
-msgstr "Old Versions"
+msgstr "Versiones antiguas"
 
 #. module: project_version
 #: model:ir.model.fields,field_description:project_version.field_project_project_parent_id
 msgid "Parent Project"
-msgstr "Parent Project"
+msgstr "Proyecto padre"
 
 #. module: project_version
 #: model:ir.model,name:project_version.model_project_project

--- a/project_version/models/__init__.py
+++ b/project_version/models/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import project_project

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -7,12 +7,12 @@ from odoo import api, fields, models
 class ProjectProject(models.Model):
     _inherit = 'project.project'
 
-    historical_date = fields.Date(string='Historical Date', readonly=True)
+    historical_date = fields.Date(string='Historified on', readonly=True)
     historical_user_id = fields.Many2one(
-        comodel_name='res.users', string='Historifying User', readonly=True)
-    version_date = fields.Date(string='Version Date', readonly=True)
+        comodel_name='res.users', string='Historified by', readonly=True)
+    version_date = fields.Date(string='Versioned on', readonly=True)
     version_user_id = fields.Many2one(
-        comodel_name='res.users', string='Versioning User', readonly=True)
+        comodel_name='res.users', string='Versioned by', readonly=True)
     version = fields.Integer(string='Version', copy=False, default=1)
     parent_id = fields.Many2one(
         comodel_name='project.project', string='Parent Project', copy=False)
@@ -33,6 +33,8 @@ class ProjectProject(models.Model):
     @api.multi
     def button_new_version(self):
         self.ensure_one()
+        if self.historical_date or self.historical_user_id or not self.active:
+            return False
         self._copy_project()
         revno = self.version
         self.write({
@@ -52,6 +54,8 @@ class ProjectProject(models.Model):
 
     @api.multi
     def button_historical(self):
+        if self.historical_date or self.historical_user_id or not self.active:
+            return False
         self.write({
             'active': False,
             'historical_date': fields.Date.today(),

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -10,9 +10,12 @@ class ProjectProject(models.Model):
     historical_date = fields.Date(string='Historified on', readonly=True)
     historical_user_id = fields.Many2one(
         comodel_name='res.users', string='Historified by', readonly=True)
-    version_date = fields.Date(string='Versioned on', readonly=True)
+    version_date = fields.Date(
+        string='Versioned on', readonly=True, copy=False,
+        default=fields.Date.context_today)
     version_user_id = fields.Many2one(
-        comodel_name='res.users', string='Versioned by', readonly=True)
+        comodel_name='res.users', string='Versioned by', readonly=True,
+        copy=False, default=lambda self: self.env.user)
     version = fields.Integer(string='Version', copy=False, default=1)
     parent_id = fields.Many2one(
         comodel_name='project.project', string='Parent Project', copy=False)
@@ -46,6 +49,8 @@ class ProjectProject(models.Model):
     def _copy_project(self):
         new_test = self.copy({
             'version': self.version,
+            'version_date': self.version_date,
+            'version_user_id': self.version_user_id.id,
             'name': self.name,
             'parent_id': self.id,
         })

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -1,0 +1,59 @@
+# Copyright 2018 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo import api, fields, models
+
+
+class ProjectProject(models.Model):
+    _inherit = 'project.project'
+
+    historical_date = fields.Date(string='Historical Date', readonly=True)
+    version = fields.Integer(string='Version', copy=False, default=1)
+    parent_id = fields.Many2one(
+        comodel_name='project.project', string='Parent Project', copy=False)
+    old_version_ids = fields.Many2many(
+        comodel_name='project.project', string='Old Versions',
+        compute='_compute_old_versions')
+
+    @api.multi
+    def _compute_old_versions(self):
+        for project in self:
+            parent = project.parent_id
+            old_version = self.env['project.project']
+            while parent:
+                old_version += parent
+                parent = parent.parent_id
+            project.old_version_ids = old_version
+
+    @api.multi
+    def button_new_version(self):
+        self.ensure_one()
+        new_project = self._copy_project()
+        self.button_historical()
+        return {
+            'type': 'ir.actions.act_window',
+            'view_type': 'form, tree',
+            'view_mode': 'form',
+            'res_model': 'project.project',
+            'res_id': new_project.id,
+            'target': 'current',
+        }
+
+    def _copy_project(self):
+        # active_draft = self.env['mrp.config.settings']._get_parameter(
+        #     'active.draft')
+        new_project = self.copy({
+            'name': self.name,
+            'version': self.version + 1,
+            # 'active': active_draft and active_draft.value or False,
+            'parent_id': self.id,
+        })
+        return new_project
+
+    @api.multi
+    def button_historical(self):
+        self.write({
+            # 'active': False,
+            # 'state': 'historical',
+            'historical_date': fields.Date.today()
+        })

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -21,6 +21,11 @@ class ProjectProject(models.Model):
         comodel_name='project.project', string='Parent Project', copy=False)
 
     @api.multi
+    def write(self, values):
+        res = super(ProjectProject, self).write(values)
+        return res
+
+    @api.multi
     def button_new_version(self):
         self.ensure_one()
         if self.historical_date or self.historical_user_id or not self.active:
@@ -40,6 +45,7 @@ class ProjectProject(models.Model):
             'version_user_id': self.version_user_id.id,
             'name': self.name,
             'parent_id': self.id,
+            'active': False,
         })
         return new_test
 

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -19,19 +19,6 @@ class ProjectProject(models.Model):
     version = fields.Integer(string='Version', copy=False, default=1)
     parent_id = fields.Many2one(
         comodel_name='project.project', string='Parent Project', copy=False)
-    old_version_ids = fields.Many2many(
-        comodel_name='project.project', string='Old Versions',
-        compute='_compute_old_versions')
-
-    @api.multi
-    def _compute_old_versions(self):
-        for project in self:
-            parent = project.parent_id
-            old_version = self.env['project.project']
-            while parent:
-                old_version += parent
-                parent = parent.parent_id
-            project.old_version_ids = old_version
 
     @api.multi
     def button_new_version(self):

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -41,15 +41,15 @@ class ProjectProject(models.Model):
             'name': self.name,
             'parent_id': self.id,
         })
-        new_test.button_historical()
         return new_test
 
     @api.multi
     def button_historical(self):
+        self.ensure_one()
         if self.historical_date or self.historical_user_id or not self.active:
             return False
-        self.write({
-            'active': False,
+        copy = self._copy_project()
+        copy.write({
             'historical_date': fields.Date.today(),
             'historical_user_id': self.env.user.id,
         })

--- a/project_version/models/project_project.py
+++ b/project_version/models/project_project.py
@@ -16,7 +16,8 @@ class ProjectProject(models.Model):
     version_user_id = fields.Many2one(
         comodel_name='res.users', string='Versioned by', readonly=True,
         copy=False, default=lambda self: self.env.user)
-    version = fields.Integer(string='Version', copy=False, default=1)
+    version = fields.Integer(
+        string='Version', readonly=True, copy=False, default=1)
     parent_id = fields.Many2one(
         comodel_name='project.project', string='Parent Project', copy=False)
 

--- a/project_version/tests/__init__.py
+++ b/project_version/tests/__init__.py
@@ -1,0 +1,4 @@
+# Copyright 2018 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from . import test_project_version

--- a/project_version/tests/test_project_version.py
+++ b/project_version/tests/test_project_version.py
@@ -8,8 +8,8 @@ class TestProjectVersion(common.SavepointCase):
     @classmethod
     def setUpClass(cls):
         super(TestProjectVersion, cls).setUpClass()
-        project_model = cls.env['project.project']
-        cls.project = project_model.create({
+        cls.project_model = cls.env['project.project']
+        cls.project = cls.project_model.create({
             'name': 'Test Project',
         })
 
@@ -17,6 +17,18 @@ class TestProjectVersion(common.SavepointCase):
         self.assertEquals(self.project.version, 1)
         self.project.button_new_version()
         self.assertEquals(self.project.version, 2)
+        old_versions = self.project_model.with_context(
+            active_test=False).search([
+                ('parent_id', '=', self.project.id),
+                '|', ('historical_user_id', '=', False),
+                ('historical_date', '=', False)
+            ])
+        self.assertEquals(len(old_versions), self.project.version - 1)
         project = self.project.copy()
         self.assertEquals(project.version, 1)
         self.assertNotEquals(project.version, self.project.version)
+
+    def test_project_historify(self):
+        self.assertEquals(self.project.version, 1)
+        self.project.button_historical()
+        self.assertEquals(self.project.version, 1)

--- a/project_version/tests/test_project_version.py
+++ b/project_version/tests/test_project_version.py
@@ -1,0 +1,22 @@
+# Copyright 2018 Oihane Crucelaegui - AvanzOSC
+# License AGPL-3 - See http://www.gnu.org/licenses/agpl-3.0.html
+
+from odoo.tests import common
+
+
+class TestProjectVersion(common.SavepointCase):
+    @classmethod
+    def setUpClass(cls):
+        super(TestProjectVersion, cls).setUpClass()
+        project_model = cls.env['project.project']
+        cls.project = project_model.create({
+            'name': 'Test Project',
+        })
+
+    def test_project_version_vs_copy(self):
+        self.assertEquals(self.project.version, 1)
+        self.project.button_new_version()
+        self.assertEquals(self.project.version, 2)
+        project = self.project.copy()
+        self.assertEquals(project.version, 1)
+        self.assertNotEquals(project.version, self.project.version)

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -47,6 +47,20 @@
         </field>
     </record>
 
+    <record id="project_project_tree_view" model="ir.ui.view">
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project" />
+        <field name="arch" type="xml">
+            <field name="partner_id" position="after">
+                <field name="version" />
+                <field name="historical_user_id" />
+                <field name="historical_date" />
+                <field name="version_user_id" />
+                <field name="version_date" />
+            </field>
+        </field>
+    </record>
+
     <record id="project_project_search_view" model="ir.ui.view">
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.view_project_project_filter" />

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -4,9 +4,22 @@
         <field name="name">Old Versions</field>
         <field name="res_model">project.project</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="domain">[('parent_id','=',active_id),('','',)]</field>
+        <field name="domain">[('parent_id','=',active_id),'|',('historical_user_id','=',False),('historical_date','=',False)]</field>
         <field name="context">{
             'active_test': False,
+            'show_version_info': False,
+        }</field>
+    </record>
+
+    <record id="project_project_history_action" model="ir.actions.act_window">
+        <field name="name">History</field>
+        <field name="res_model">project.project</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="domain">[('parent_id','=',active_id),'|',('historical_user_id','!=',False),('historical_date','!=',False)]</field>
+        <field name="context">{
+            'active_test': False,
+            'show_version_info': False,
+            'show_history_info': False,
         }</field>
     </record>
 
@@ -40,9 +53,12 @@
                 </header>
             </sheet>
             <div name="button_box" position="inside">
-                 <button string="Old Versions" class="oe_stat_button" icon="fa-archive"
-                         name="%(project_project_old_version_action)d" type="action"
-                         attrs="{'invisible': [('parent_id','!=',False)]}" />
+                <button string="Old Versions" class="oe_stat_button" icon="fa-archive"
+                        name="%(project_project_old_version_action)d" type="action"
+                        attrs="{'invisible': [('parent_id','!=',False)]}" />
+                <button string="History" class="oe_stat_button" icon="fa-archive"
+                        name="%(project_project_history_action)d" type="action"
+                        attrs="{'invisible': [('parent_id','!=',False)]}" />
             </div>
         </field>
     </record>
@@ -53,10 +69,10 @@
         <field name="arch" type="xml">
             <field name="partner_id" position="after">
                 <field name="version" />
-                <field name="historical_user_id" />
-                <field name="historical_date" />
-                <field name="version_user_id" />
-                <field name="version_date" />
+                <field name="version_user_id" invisible="context.get('show_version_info',True)" />
+                <field name="version_date" invisible="context.get('show_version_info',True)" />
+                <field name="historical_user_id" invisible="context.get('show_history_info',True)" />
+                <field name="historical_date" invisible="context.get('show_history_info',True)" />
             </field>
         </field>
     </record>
@@ -67,7 +83,9 @@
         <field name="arch" type="xml">
             <filter name="inactive" position="after">
                 <separator />
-                <filter string="Historified" name="history" domain="[('historical_date','!=',False)]"/>
+                <filter string="Historified" name="history"
+                        domain="['|',('historical_date','!=',False),('historical_user_id','!=',False)]"
+                        context="{'show_history_info': False, 'active_test': False}"/>
                 <filter string="All" name="all_project" domain="['|',('historical_date','!=',False),('historical_date','=',False)]"/>
             </filter>
         </field>

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Old Versions</field>
         <field name="res_model">project.project</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="domain">[('parent_id','=',active_id),'|',('historical_user_id','=',False),('historical_date','=',False)]</field>
+        <field name="domain">[('parent_id','=',active_id),('historical_user_id','=',False),('historical_date','=',False)]</field>
         <field name="context">{
             'active_test': False,
             'show_version_info': False,

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -4,7 +4,7 @@
         <field name="name">Old Versions</field>
         <field name="res_model">project.project</field>
         <field name="view_mode">tree,kanban,form</field>
-        <field name="domain">[('parent_id','=',active_id)]</field>
+        <field name="domain">[('parent_id','=',active_id),('','',)]</field>
         <field name="context">{
             'active_test': False,
         }</field>

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -1,11 +1,35 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <odoo>
+    <record id="project_project_old_version_action" model="ir.actions.act_window">
+        <field name="name">Old Versions</field>
+        <field name="res_model">project.project</field>
+        <field name="view_mode">tree,kanban,form</field>
+        <field name="domain">[('parent_id','=',active_id)]</field>
+        <field name="context">{
+            'active_test': False,
+        }</field>
+    </record>
+
     <record id="project_project_form_view" model="ir.ui.view">
         <field name="model">project.project</field>
         <field name="inherit_id" ref="project.edit_project" />
         <field name="arch" type="xml">
             <field name="sequence" position="after">
                 <field name="version" />
+                <field name="parent_id" invisible="True" />
+                <label for="version_user_id"
+                       attrs="{'invisible': ['|',('version_user_id','=',False),('version_date','=',False)]}"/>
+                <div attrs="{'invisible': ['|',('version_user_id','=',False),('version_date','=',False)]}">
+                    <field name="version_user_id" class="oe_inline" /> on
+                    <field name="version_date" class="oe_inline" />
+
+                </div>
+                <label for="historical_user_id"
+                       attrs="{'invisible': ['|',('historical_user_id','=',False),('historical_date','=',False)]}"/>
+                <div attrs="{'invisible': ['|',('historical_user_id','=',False),('historical_date','=',False)]}">
+                    <field name="historical_user_id" class="oe_inline" /> on
+                    <field name="historical_date"  class="oe_inline" />
+                </div>
             </field>
             <sheet position="before">
                 <header>
@@ -15,6 +39,24 @@
                             string="Historify" />
                 </header>
             </sheet>
+            <div name="button_box" position="inside">
+                 <button string="Old Versions" class="oe_stat_button" icon="fa-archive"
+                         name="%(project_project_old_version_action)d" type="action"
+                         attrs="{'invisible': [('parent_id','!=',False)]}" />
+            </div>
         </field>
     </record>
+
+    <record id="project_project_search_view" model="ir.ui.view">
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.view_project_project_filter" />
+        <field name="arch" type="xml">
+            <filter name="inactive" position="after">
+                <separator />
+                <filter string="Historified" name="history" domain="[('historical_date','!=',False)]"/>
+                <filter string="All" name="all_project" domain="['|',('historical_date','!=',False),('historical_date','=',False)]"/>
+            </filter>
+        </field>
+    </record>
+
 </odoo>

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -11,6 +11,8 @@
                 <header>
                     <button name="button_new_version" type="object"
                             string="New Version" />
+                    <button name="button_historical" type="object"
+                            string="Historify" />
                 </header>
             </sheet>
         </field>

--- a/project_version/views/project_project_view.xml
+++ b/project_version/views/project_project_view.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8" ?>
+<odoo>
+    <record id="project_project_form_view" model="ir.ui.view">
+        <field name="model">project.project</field>
+        <field name="inherit_id" ref="project.edit_project" />
+        <field name="arch" type="xml">
+            <field name="sequence" position="after">
+                <field name="version" />
+            </field>
+            <sheet position="before">
+                <header>
+                    <button name="button_new_version" type="object"
+                            string="New Version" />
+                </header>
+            </sheet>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
NUEVA VERSION:
Para ello, se necesita lo siguiente:
.- Añadir un campo "número de revisión": de tipo entero. Valor por defecto =1. Se propone dejarlo editable para que el usuario ajuste como quiera este campo aunque se puede cerrar y poner "no editable"
.- Añadir en proyectos los campos "fecha última revisión" y "fecha último revisor" (No editables). Al crear el proyecto dejar vacías. Solo se informarán o modificarán en el momento que se cree una revisión del mismo.
Al pulsar "Nueva revisión": 
  - Realizar "copia del proyecto" igual que hace la historificación. ¿Inactiva y no editable? En el nombre de la copia añadir estado y número de revisión entre paréntesis de tal forma que quedaría algo así: Proyecto XXXX- Oferta(1),  Proyecto XXXX-Oferta(2), Proyecto XXXX- Ejecución(1) ... etc.
  - Incrementa en 1 el campo "número de revisión" del proyecto activo. 
  - Informar el campo "fecha última revisión" del proyecto activo con la fecha en la que se hace la revisión.
  - Informar el campo "último revisor" del proyecto activo con el usuario que ha realizado la revisión.

Al historificar un proyecto se realizarán las siguientes acciones:
- Copiar el proyecto actual en un nuevo proyecto (crear proyecto copia)
- En la copia, Informar fecha y usuario de historificación (no editables. Se informarán automáticamente y no se podrán cambiar)
- En la copia Informar proyecto origen, con el id del proyecto que se historificó. (No editable. Se informa automáticamente) 
- Poner el campo "activo" del proyecto copia a "inactivo" 
- Hacer que el proyecto "copia" no sea editable.
- Poner el estado y la palabra "Histórico" detrás del nombre del proyecto copia. De tal forma que quedará Proyecto XXX-Idea viabilidad-Histórico

Tener en cuenta que habrá que historificar también los datos de tablas relacionadas (riesgos, viabilidad, financiación... etc. Incluidas TAREAS. A fin de evitar que estas tareas históricas se mezclen con las activas, crearlas también en estado Inactivo)