### PR TITLE
11.0

### DIFF
--- a/project_characterization/i18n/eu_ES.po
+++ b/project_characterization/i18n/eu_ES.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 11.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2018-12-17 14:20+0000\n"
-"PO-Revision-Date: 2018-12-17 14:20+0000\n"
+"POT-Creation-Date: 2021-01-25 15:01+0000\n"
+"PO-Revision-Date: 2021-01-25 15:01+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -18,27 +18,27 @@ msgstr ""
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_activity_menuitem
 msgid "Activity"
-msgstr "Actividad"
+msgstr "Jarduera"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_activity_type_menuitem
 msgid "Activity Type"
-msgstr "Tipo de actividad"
+msgstr "Jarduera-mota"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_res_config_settings_manual_code
 msgid "Add number manually to compose account code"
-msgstr "Añadir manualmente el número para el código de cuenta"
+msgstr "Kontu-koderako zenbakia eskuz gehitzea"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_account_analytic_account
 msgid "Analytic Account"
-msgstr "Cuenta analítica"
+msgstr "Kontu analitikoa"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_account_analytic_line
 msgid "Analytic Line"
-msgstr "Línea Analítica"
+msgstr "Lerro analitikoa"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_res_area_id
@@ -46,35 +46,35 @@ msgstr "Línea Analítica"
 #: model:ir.ui.menu,name:project_characterization.res_area_menuitem
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 msgid "Area"
-msgstr "Área"
+msgstr "Arloa"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_area_specialization_menuitem
 msgid "Area Specialization"
-msgstr "Área de especialización"
+msgstr "Espezializazio arloa"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_area_type_menuitem
 msgid "Area Type"
-msgstr "Tipo de proyecto"
+msgstr "Arlo-mota"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_res_area_type_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_res_area_type_id
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 msgid "Area type"
-msgstr "Tipo de área"
+msgstr "Arlo-mota"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_res_area_type
 msgid "Area types"
-msgstr "Tipos de proyecto"
+msgstr "Arlo-motak"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_res_area
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Areas"
-msgstr "Áreas"
+msgstr "Arloak"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_res_character_id
@@ -82,50 +82,50 @@ msgstr "Áreas"
 #: model:ir.ui.menu,name:project_characterization.res_character_menuitem
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 msgid "Character"
-msgstr "Naturaleza"
+msgstr "Natura"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.project_characterization_config_menuitem
 #: model:ir.ui.view,arch_db:project_characterization.project_project_form_view
 msgid "Characterization"
-msgstr "Caracterización"
+msgstr "Karakterizazioa"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Characters"
-msgstr "Naturalezas"
+msgstr "Natura"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_committee_menuitem
 msgid "Committee"
-msgstr "Comité"
+msgstr "Batzordea"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_create_uid
 msgid "Created by"
-msgstr "Creado por"
+msgstr "Nork sortua"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_create_date
 msgid "Created on"
-msgstr "Creado el"
+msgstr "Noiz sortua"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_description
 msgid "Description"
-msgstr "Descripción"
+msgstr "Deskribapena"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_display_name
 msgid "Display Name"
-msgstr "Nombre a Mostrar"
+msgstr "Izena erakutsi"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_project_form_view
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 #: model:ir.ui.view,arch_db:project_characterization.project_project_tree_view
 msgid "End Date"
-msgstr "Fecha de finalización"
+msgstr "Amaiera data"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_id
@@ -135,38 +135,38 @@ msgstr "ID"
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_project_form_view
 msgid "Initial Date"
-msgstr "Fecha inicio"
+msgstr "Hasiera data"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_justification_deadline
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_justification_deadline
 msgid "Justification Deadline"
-msgstr "Justificación Fecha límite"
+msgstr "Azken egunaren justifikazioa"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2___last_update
 msgid "Last Modified on"
-msgstr "Última modificación en"
+msgstr "Azken aldaketa"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_write_uid
 msgid "Last Updated by"
-msgstr "Última actualización de"
+msgstr "Azkenengoz eguneratu zuena"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_write_date
 msgid "Last Updated on"
-msgstr "Última actualización en"
+msgstr "Azken eguneraketa noiz"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_config_settings_form_view
 msgid "Manual Code for Analytic Accounts"
-msgstr "Código manual para cuenta analítica"
+msgstr "Kontu analitikorako eskuzko kodea"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_name
 msgid "Name"
-msgstr "Nombre"
+msgstr "Izena"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_nonoperative
@@ -178,13 +178,13 @@ msgstr "Nombre"
 #: model:ir.ui.view,arch_db:project_characterization.res_area_operative_search_view
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Non Operative"
-msgstr "No operativo"
+msgstr "Ez dabil"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_num_code
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_num_code
 msgid "Number"
-msgstr "Número"
+msgstr "Zenbakia "
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.account_analytic_line_search_view
@@ -192,55 +192,55 @@ msgstr "Número"
 #: model:ir.ui.view,arch_db:project_characterization.res_area_operative_search_view
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Operative"
-msgstr "Operativo"
+msgstr "Operatiboa"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_op_space_id
 #: model:ir.model.fields,field_description:project_characterization.field_project_project_op_space_id
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 msgid "Opportunity Space"
-msgstr "Espacio de oportunidad"
+msgstr "Aukerako espazioa"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_opportunity_space_menuitem
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Opportunity Spaces"
-msgstr "Espacios de oportunidad"
+msgstr "Aukerako espazioak"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_task_form_view
 msgid "Period"
-msgstr "Período"
+msgstr "Aldiak"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_project
 msgid "Project"
-msgstr "Proyecto"
+msgstr "Proiektu"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_task_type2_form_view
 msgid "Project Task Type"
-msgstr "Tipos de tarea de proyecto"
+msgstr "Proiektuko ataza motak"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_res_area_type_project_ids
 msgid "Projects"
-msgstr "Proyectos"
+msgstr "Proiektuak "
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_res_area_related_operative_area_ids
 msgid "Related Operative Area"
-msgstr "Areas Operativas"
+msgstr "Arlo operatiboak"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.project_config_settings_form_view
 msgid "Select number to compose analytic account code"
-msgstr "Seleccionar un número para obtener el código de cuenta analítica"
+msgstr "Hautatu zenbaki bat kontu analitikoaren kodea lortzeko"
 
 #. module: project_characterization
 #: model:ir.ui.menu,name:project_characterization.res_structure_menuitem
 msgid "Structures"
-msgstr "Estructuras"
+msgstr "Egiturak"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_res_target_id
@@ -248,22 +248,22 @@ msgstr "Estructuras"
 #: model:ir.ui.menu,name:project_characterization.res_target_menuitem
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 msgid "Target"
-msgstr "Sector Objetivo"
+msgstr "Sektore objektiboa"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Targets"
-msgstr "Sectores objetivos"
+msgstr "Sektore objektiboak"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_task
 msgid "Task"
-msgstr "Tarea"
+msgstr "Ataza"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_project_task_type2
 msgid "Task Type"
-msgstr "Tipo de tarea"
+msgstr "Ataza mota"
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_account_analytic_account_res_team_id
@@ -271,22 +271,22 @@ msgstr "Tipo de tarea"
 #: model:ir.ui.menu,name:project_characterization.res_team_menuitem
 #: model:ir.ui.view,arch_db:project_characterization.project_project_search_view
 msgid "Team"
-msgstr "Equipo"
+msgstr "Taldea"
 
 #. module: project_characterization
 #: model:ir.ui.view,arch_db:project_characterization.view_account_analytic_account_search_inh_project_char
 msgid "Teams"
-msgstr "Equipos"
+msgstr "Taldeak"
 
 #. module: project_characterization
 #: model:ir.model.fields,help:project_characterization.field_res_config_settings_manual_code
 msgid "This will disable automatic number adding to create analytic account code in projects."
-msgstr "Esto deshabilita la generación de número aútomatico para obtener el código de cuenta analítica."
+msgstr "This will disable automatic number adding to create analytic account code in projects."
 
 #. module: project_characterization
 #: model:ir.model.fields,field_description:project_characterization.field_project_task_type2_id_7406
 msgid "Type"
-msgstr "Tipo"
+msgstr "Mota"
 
 #. module: project_characterization
 #: model:ir.model,name:project_characterization.model_res_config_settings

--- a/project_characterization/models/project_task.py
+++ b/project_characterization/models/project_task.py
@@ -7,7 +7,7 @@ from odoo import fields, models
 class ProjectTask(models.Model):
     _inherit = 'project.task'
 
-    type_id = fields.Many2one(
+    type2_id = fields.Many2one(
         comodel_name='project.task.type2', string='Type')
 
 

--- a/project_characterization/views/project_task_view.xml
+++ b/project_characterization/views/project_task_view.xml
@@ -6,7 +6,7 @@
         <field name="inherit_id" ref="project.view_task_form2" />
         <field name="arch" type="xml">
             <field name="tag_ids" position="after">
-                <field name="type_id" />
+                <field name="type2_id" />
             </field>
             <field name="date_deadline" position="before">
                 <label for="date_from" string="Period"/>


### PR DESCRIPTION
In the project_characterization module, the type_id field of the project.task model is defined. This definition conflicts with the definition of the field with the same name in the project_category module of the OCA. This causes an error in the task form, if both modules are installed.